### PR TITLE
Add manual page on resetting Jenkins build numbers

### DIFF
--- a/architecture-decision-records/0002-versioning-and-deployments.md
+++ b/architecture-decision-records/0002-versioning-and-deployments.md
@@ -54,7 +54,8 @@ scratch, we can set the next build numbers so they start from the next version
 rather than resetting back to build 1. To do this, you can run a script in the
 [Jenkins script console][script-console]:
 
-```def job = Jenkins.instance.getItemByFullName("name-of-jenkins-build/master")
+```
+def job = Jenkins.instance.getItemByFullName("name-of-jenkins-build/master")
 job.nextBuildNumber = 123
 job.save()
 ```

--- a/manual/reset-jenkins-builds.md
+++ b/manual/reset-jenkins-builds.md
@@ -1,0 +1,32 @@
+# Reset Jenkins build numbers
+
+Some of the TDR projects [get their deployment version numbers from the Jenkins
+build number](../architecture-decision-records/0002-versioning-and-deployments.md).
+
+Sometimes these numbers get out of sync. This might happen if Jenkins is
+deployed without restoring a backup of the old build jobs, or if the backup is
+out of date and doesn't include recent deployments.
+
+In that case, you will see an error like this in the Jenkins job console:
+
+```
+05:55:52  To github.com:nationalarchives/tdr-consignment-api.git
+05:55:52   ! [rejected]        v35 -> v35 (already exists)
+05:55:52  error: failed to push some refs to 'git@github.com:nationalarchives/tdr-consignment-api.git'
+05:55:52  hint: Updates were rejected because the tag already exists in the remote.
+```
+
+You can fix the issue by resetting the build number in Jenkins:
+
+Go to the Jenkins script console at https://ci.integration.publishing.service.gov.uk/script
+
+Run:
+
+```
+def job = Jenkins.instance.getItemByFullName("your-project-name/master")
+job.nextBuildNumber = 1234
+job.save()
+```
+
+Where `your-project-name` is the name of the Jenkins build, and `1234` is the
+next available release tag.


### PR DESCRIPTION
This fixes deployment errors when a version tag already exists.