### PR TITLE
Add jenkins style guide.

### DIFF
--- a/manual/README.md
+++ b/manual/README.md
@@ -5,13 +5,14 @@ things like deploying code or debugging complex parts of the stack.
 
 ## Guides
 
-* [Create a repo](create-repo.md)
-* [Setup TDR AWS Infrastructure](tdr-create-aws-instructure-setup.md)
-* [Retrieve Authorisation Token From Keycloak](keycloak-retrieve-token.md)
-* [Reset Jenkins Builds](reset-jenkins-builds.md)
-* [Update Jenkins](update-jenkins.md)
+- [Create a repo](create-repo.md)
+- [Setup TDR AWS Infrastructure](tdr-create-aws-instructure-setup.md)
+- [Retrieve Authorisation Token From Keycloak](keycloak-retrieve-token.md)
+- [Reset Jenkins Builds](reset-jenkins-builds.md)
+- [Update Jenkins](update-jenkins.md)
+- [Jenkins style guide](jenkins-style-guide.md)
 
 ### Development processes
 
-* [Close a card](development-process/close-card.md)
-* [Plan a user story](plan-story.md)
+- [Close a card](development-process/close-card.md)
+- [Plan a user story](plan-story.md)

--- a/manual/README.md
+++ b/manual/README.md
@@ -5,14 +5,14 @@ things like deploying code or debugging complex parts of the stack.
 
 ## Guides
 
-- [Create a repo](create-repo.md)
-- [Setup TDR AWS Infrastructure](tdr-create-aws-instructure-setup.md)
-- [Retrieve Authorisation Token From Keycloak](keycloak-retrieve-token.md)
-- [Reset Jenkins Builds](reset-jenkins-builds.md)
-- [Update Jenkins](update-jenkins.md)
-- [Jenkins style guide](jenkins-style-guide.md)
+* [Create a repo](create-repo.md)
+* [Setup TDR AWS Infrastructure](tdr-create-aws-instructure-setup.md)
+* [Retrieve Authorisation Token From Keycloak](keycloak-retrieve-token.md)
+* [Reset Jenkins Builds](reset-jenkins-builds.md)
+* [Update Jenkins](update-jenkins.md)
+* [Jenkins style guide](jenkins-style-guide.md)
 
 ### Development processes
 
-- [Close a card](development-process/close-card.md)
-- [Plan a user story](plan-story.md)
+* [Close a card](development-process/close-card.md)
+* [Plan a user story](plan-story.md)

--- a/manual/jenkins-style-guide.md
+++ b/manual/jenkins-style-guide.md
@@ -2,4 +2,4 @@
 
 This is the style guide for writing Jenkins pipeline files.
 
-- Use 2 spaces for indentation
+* Use 2 spaces for indentation

--- a/manual/jenkins-style-guide.md
+++ b/manual/jenkins-style-guide.md
@@ -1,0 +1,5 @@
+# Jenkins style guide
+
+This is the style guide for writing Jenkins pipeline files.
+
+- Use 2 spaces for indentation


### PR DESCRIPTION
This is only one item at the moment which is to use two spaces. We may add more if we start needing it for the jenkinslib functions.