### PR TITLE
Update links to Jenkins backup instructions

### DIFF
--- a/manual/alerts/missed-jenkins-backups.md
+++ b/manual/alerts/missed-jenkins-backups.md
@@ -15,9 +15,9 @@ Last Ping  Total Pings
 To investigate why the backup didn't run, check the [Maintenance Window history]
 in the TDR Management AWS account.
 
-To manually initiate a backup, go the [Systems Manager Command History], select
-a previous Jenkins backup and click Rerun.
+To manually initiate a backup, follow the [instructions in the Jenkins
+Readme][backup-guide].
 
 [healthchecks.io]: https://healthchecks.io/
 [Maintenance Window history]: https://eu-west-2.console.aws.amazon.com/systems-manager/maintenance-windows/mw-0bd9ef68cfe04bd4e/history?region=eu-west-2
-[Systems Manager Command History]: https://eu-west-2.console.aws.amazon.com/systems-manager/run-command/complete-commands?region=eu-west-2
+[backup-guide]: https://github.com/nationalarchives/tdr-jenkins#backups

--- a/manual/update-jenkins.md
+++ b/manual/update-jenkins.md
@@ -94,7 +94,7 @@ Any issues with the updates might only appear when you run a Jenkins job, so
 test the update by running some branch builds and integration deployments.
 
 [tdr-jenkins]: https://github.com/nationalarchives/tdr-jenkins/
-[TDR Jenkins Backup]: https://jenkins.tdr-management.nationalarchives.gov.uk/job/TDR%20Jenkins%20Backup/
+[TDR Jenkins Backup]: https://github.com/nationalarchives/tdr-jenkins#backups
 [reset-builds]: reset-jenkins-builds.md
 [ecs-ami]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
 [jenkins-service-mgmt]: https://eu-west-2.console.aws.amazon.com/ecs/home?region=eu-west-2#/clusters/jenkins-mgmt/services/jenkins-service-mgmt/events


### PR DESCRIPTION
The Jenkins backup job has been moved from Jenkins itself to an AWS maintenance window, and there are more comprehensive instructions in the tdr-jenkins Readme.