### PR TITLE
Fix Markdown syntax on dev manual page

### DIFF
--- a/manual/README.md
+++ b/manual/README.md
@@ -19,7 +19,7 @@ things like deploying code or debugging complex parts of the stack.
 
 ### Debugging
 
-* [Debug failing file checks](debugging/debug-file-checks.md)
+* [Debug failing file checks](debugging/file-checks-do-not-run.md)
 
 ### Development processes
 

--- a/manual/README.md
+++ b/manual/README.md
@@ -14,12 +14,12 @@ things like deploying code or debugging complex parts of the stack.
 
 ### Alerts
 
-* [Missed Jenkins backups][alerts/missed-jenkins-backups.md]
-* [Rotate AWS keys][alerts/rotate-aws-keys.md]
+* [Missed Jenkins backups](alerts/missed-jenkins-backups.md)
+* [Rotate AWS keys](alerts/rotate-aws-keys.md)
 
 ### Debugging
 
-* [Debug failing file checks][debugging/debug-file-checks.md]
+* [Debug failing file checks](debugging/debug-file-checks.md)
 
 ### Development processes
 


### PR DESCRIPTION
This fixes the links to the alerts and debugging pages.